### PR TITLE
FEAT - Sorting published_at with nulls last

### DIFF
--- a/app/models/blog_post.rb
+++ b/app/models/blog_post.rb
@@ -2,7 +2,7 @@ class BlogPost < ApplicationRecord
     validates :title, presence: true
     validates :body, presence: true
 
-    scope :sorted, -> { order(published_at: :desc, updated_at: :desc) }
+    scope :sorted, -> { order(arel_table[:published_at].desc.nulls_last).order(updated_at: :desc) }
     scope :draft, -> { where(published_at: nil) }
     scope :published, -> { where("published_at <= ?", Time.current) }
     scope :scheduled, -> { where("published_at > ?", Time.current) }


### PR DESCRIPTION
I want to display draft blog posts in the last, so I made this change.
New ordering:
- Scheduled
- Published
- Draft